### PR TITLE
Packages: Install `unzip` and `tar` packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN dnf makecache fast \
       sudo \
       which \
       python2-dnf \
+      tar.x86_64 \
+      unzip \
  && dnf clean all
 
 # Disable requiretty.


### PR DESCRIPTION
When trying to use the `unarchive` Ansible module with this container, will result in similar to the following:

```
... Make sure the required command to extract the file is installed.
Commands \"gtar\" and \"tar\" not found. Command \"unzip\"
not found."}
```

Fixes #1